### PR TITLE
hm-mod: uwsm: init with options env and sourceSessionVariables

### DIFF
--- a/hm-module/default.nix
+++ b/hm-module/default.nix
@@ -18,5 +18,6 @@ in {
     ./monitors.nix
     ./devices.nix
     ./portal.nix
+    ./uwsm.nix
   ];
 }

--- a/hm-module/uwsm.nix
+++ b/hm-module/uwsm.nix
@@ -1,5 +1,5 @@
 { lib, ... }:
-{ config, ... }:
+{ config, osConfig ? null, ... }:
 let
   cfg = config.programs.uwsm;
 
@@ -17,13 +17,17 @@ in {
       };
       sourceSessionVariables = lib.mkOption {
         type = lib.types.bool;
-        default = false;
+        default = osConfig.programs.uwsm.enable or true;
+        defaultText = ''
+          Enabled by default if:
+            - you are using Home Manager as a NixOS module and have `programs.uwsm.enable = true`,
+            - or if Home Manager is running "standalone" (can't know if UWSM is enabled).
+        '';
         description = ''
           Whether to link Home Manager's session variables script
           (`hm-session-vars.sh`) to `$XDG_CONFIG_HOME/uwsm/env`.
 
-          It is highly recommended to enable this option if you are using the UWSM
-          NixOS module.
+          Disable this option if you do not use UWSM as a NixOS module.
         '';
       };
     };

--- a/hm-module/uwsm.nix
+++ b/hm-module/uwsm.nix
@@ -1,0 +1,43 @@
+{ lib, ... }:
+{ config, ... }:
+let
+  cfg = config.programs.uwsm;
+
+  hmSessionVars =
+    "${config.home.sessionVariablesPackage}/etc/profile.d/hm-session-vars.sh";
+in {
+  options = {
+    programs.uwsm = {
+      env = lib.mkOption {
+        type = lib.types.lines;
+        default = "";
+        description = ''
+          Shell script lines to write to `$XDG_CONFIG_HOME/uwsm/env` to bootstrap environment.
+        '';
+      };
+      sourceSessionVariables = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Whether to link Home Manager's session variables script
+          (`hm-session-vars.sh`) to `$XDG_CONFIG_HOME/uwsm/env`.
+
+          It is highly recommended to enable this option if you are using the UWSM
+          NixOS module.
+        '';
+      };
+    };
+  };
+
+  config = lib.mkMerge [
+    (lib.mkIf (cfg.env != "") { xdg.configFile."uwsm/env".text = cfg.env; })
+    (lib.mkIf (cfg.env != "" && cfg.sourceSessionVariables) {
+      xdg.configFile."uwsm/env".text = lib.mkOrder 200 ''
+        source ${hmSessionVars}
+      '';
+    })
+    (lib.mkIf (cfg.env == "" && cfg.sourceSessionVariables) {
+      xdg.configFile."uwsm/env".source = hmSessionVars;
+    })
+  ];
+}


### PR DESCRIPTION
This fixes a problem that I had been encountering before, regarding `xdg-desktop-portal`'s user service not starting the implementations configured by `~/.config/xdg-desktop-portal/hyprland-portals.conf`. This not only fixes the problem with a missing `NIX_XDG_PORTALS_DIR` (or whatever) but presumably other idiosyncrasies.

Thanks to whoever put the solution on the wiki, I just now noticed it.

For users using UWSM as a NixOS module (the only way to use it) it is highly recommended that they add `programs.uwsm.sourceSessionVariables = true` to their Home Manager configuration, alongside compositors (*cough* hyprland *cough*).

Points of debate for reviewers:
- the attrpath of `programs.uwsm`, I'm not too sure about it. It's not a program that the user can/should execute, but a precursor to the current session, part of the system config. Looking for a better option scope :pray: 
- the name of the `env` option, currently just named after the file it represents.
- the name of `sourceSessionVariables`, have you seen any naming schemes that align better? I'm also considering just `enable`, depending on whaver `programs.uwsm` gets changed to.
- is the fallback behavior in `config` acceptable? I've attempted to reduce the number of files that the shell interpreter has to execute.
- I wish there were a way to detect if the user is using UWSM from NixOS, so that the `sourceSesseonVariables` can be enabled by default if needed.